### PR TITLE
Change the way we handle the lists in the select view

### DIFF
--- a/Views/loadConfig.py
+++ b/Views/loadConfig.py
@@ -49,7 +49,7 @@ class LoadConfigWidget(QtGui.QWidget):
 	def switchViews(self):
 		fileName = self.fileTextEdit.text()
 		self.window.configFilePath = fileName
-		self.window.showSlideMetricsView(fileName)
+		self.window.showSelectAttributesView()
 
 	# open a file dialog to pick an xlsx input file
 	def selectFile(self):

--- a/Views/saveFilesWidget.py
+++ b/Views/saveFilesWidget.py
@@ -86,9 +86,13 @@ class SaveFileWidget(QtGui.QWidget):
     # Add horizontal layout to overall layout
     layout.addLayout(browseConfigFileLayout)
 
-    navigation = NavigationWidget(self.window, None, self.switchViews)
+    navigation = NavigationWidget(self.window, self.goBack, self.switchViews)
     layout.addWidget(navigation)
 
+  # go back to attribute selection view
+  def goBack(self):
+    self.window.showSelectAttributesView()
+  
   # go to next view to select data attributes
   def switchViews(self):
 

--- a/Views/selectAttributes.py
+++ b/Views/selectAttributes.py
@@ -47,8 +47,8 @@ class SelectAttributesWidget(QtGui.QWidget):
 
   # Switches to output config view
   def goToOutputConfigView(self):
-    selected_slide_attrs = self.slideMetricsTab.getItemsFromListView(self.slideMetricsTab.selectedListWidget)
-    selected_lookzone_attrs = self.lookzoneTab.getItemsFromListView(self.lookzoneTab.selectedListWidget)
+    selected_slide_attrs = self.slideMetricsTab.getFinalChosenAttrs(self.slideMetricsTab.selectedListWidget)
+    selected_lookzone_attrs = self.lookzoneTab.getFinalChosenAttrs(self.lookzoneTab.selectedListWidget)
     self.window.showSaveFilesView(selected_slide_attrs, selected_lookzone_attrs)
     # Save state of lists in view
     self.slideMetricsTab.saveState()

--- a/ipatch.py
+++ b/ipatch.py
@@ -53,8 +53,8 @@ class Window(QtGui.QMainWindow):
     else:
       event.ignore()
 
-  # Function to show the screen for selecting slide metric attributes 
-  def showSlideMetricsView(self, configFilePath):
+  # Function to show the screen for selecting attributes 
+  def showSelectAttributesView(self):
     # First parse the experiment from the saved file path
     self.reader = WorkbookReader(str(self.experimentFilePath))
     attrs = self.reader.get_attributes()
@@ -64,8 +64,8 @@ class Window(QtGui.QMainWindow):
     # Then if there is a config file to load, load it
     saved_slide = []
     saved_lookzone = []
-    if len(configFilePath):
-      saved_attrs = Configuration.read_config_file(configFilePath)
+    if len(self.configFilePath):
+      saved_attrs = Configuration.read_config_file(self.configFilePath)
       saved_slide = saved_attrs['slide']
       saved_lookzone = saved_attrs['lookzone']
 


### PR DESCRIPTION
@mravert93 A few changes:
-Makes list widgets populated with all attributes at all times
-Hides/Shows list items when added or removed instead of having to reorder the lists by removing and adding the items every time. This change fixed a few bugs in this view such as items being added to the bottom of the list.
-This makes our filtering more expensive since it shares the hiding/showing technique and the only way to differentiate from a "removed" item and a hidden one from a filter query is to scan the other list widget to see what's visible.
-Fix bug where if we have a filter, "removing" an attribute makes it appear back in the choose list even if it doesn't match the filter.
-Adds a back button from saveFileView to selectAttributesView
-Adapted load/save gui state strategy based on changes
