### PR TITLE
Add load files progress bar

### DIFF
--- a/Views/loadFile.py
+++ b/Views/loadFile.py
@@ -128,13 +128,12 @@ class LoadFileWidget(QtGui.QWidget):
 
   # go to next view to select data attributes
   def switchViews(self):
-    # TODO: Make application open file path at this point and validate input so we can show error on this screen
     if len(self.file_names):
       # self.window.showLoadConfigView(self.file_names)
       configFilePath = self.configFileTextEdit.text()
       if len(configFilePath):
         self.window.configFilePath = configFilePath
-      self.window.showSelectAttributesView(self.file_names)
+      self.window.showLoadProgressView(self.file_names)
     else:
       self.errorMsgLabel.setText('No input file was selected. Please choose at least one input file to continue.')
 

--- a/Views/load_progress.py
+++ b/Views/load_progress.py
@@ -1,0 +1,122 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import sys
+sys.path.append("..")
+from sys import argv
+from PyQt4 import QtGui, QtCore
+import time
+from workbook_reader import WorkbookReader
+from configuration import Configuration
+from Views.selectAttributes import SelectAttributesWidget
+from heading_label import HeadingLabel
+
+# Widget that shows a progress bar for loading and reading files to get attributes
+class LoadProgress(QtGui.QWidget):
+  def __init__(self, window, experimentFilePaths, parent=None):
+    super(LoadProgress, self).__init__(parent)
+    self.window = window
+    self.experimentFilePaths = experimentFilePaths
+
+    layout = QtGui.QVBoxLayout(self)
+    # Make a heading label for the top of layout
+    heading = HeadingLabel('Please wait...this could take up to a few minutes.')
+    layout.addWidget(heading)
+    layout.addStretch()
+    # Make the progress bar
+    self.progressBar = QtGui.QProgressBar(self)
+    self.progressBar.setRange(0,100)
+    layout.addWidget(self.progressBar)
+    # Make progress text to go with progress bar
+    self.progress_text_label = QtGui.QLabel('Analyzing input files...', self)
+    self.progress_text_label.setAlignment(QtCore.Qt.AlignCenter)
+    layout.addWidget(self.progress_text_label)
+    layout.addStretch()
+
+    # Connect callbacks for progress
+    self.loadingFilesTask = ReadInputFilesThread(experimentFilePaths, self.window.configFilePath)
+    self.loadingFilesTask.notifyProgress.connect(self.onProgress)
+    self.loadingFilesTask.notifyFinished.connect(self.onFinished)
+
+    self.onStart()
+
+  # Start the task we want to keep progress of
+  def onStart(self):
+    self.loadingFilesTask.start()
+
+  # Updates UI when progress on task is made
+  def onProgress(self, i):
+    self.progressBar.setValue(i)
+    progressText = "Analyzing input files: " + str(i) + "%"
+    self.progress_text_label.setText(progressText)
+
+  # Updates UI when task is complete
+  def onFinished(self, i):
+    self.showSelectAttributesView()
+
+  # Function to show the screen for selecting attributes
+  def showSelectAttributesView(self):
+    selectAttributesWidget = SelectAttributesWidget(self.window, self.loadingFilesTask.get_slide_attrs(), self.loadingFilesTask.get_lookzone_attrs(), self.loadingFilesTask.get_saved_slide_attrs(), self.loadingFilesTask.get_saved_lookzone_attrs())
+    self.window.setCentralWidget(selectAttributesWidget)
+
+# Class to run opening and reading of input files in a separate thread
+class ReadInputFilesThread(QtCore.QThread):
+  notifyProgress = QtCore.pyqtSignal(int)
+  notifyFinished = QtCore.pyqtSignal(int)
+
+  def __init__(self, experimentFilePaths, configFilePath=None):
+    super(ReadInputFilesThread, self).__init__()
+    self.saved_slide = set()
+    self.saved_lookzone = set()
+    self.slide_attrs = []
+    self.lookzone_attrs = []
+    self.experimentFilePaths = experimentFilePaths
+    self.configFilePath = configFilePath or ''
+
+  def get_saved_slide_attrs(self):
+    return list(self.saved_slide)
+
+  def get_saved_lookzone_attrs(self):
+    return list(self.saved_lookzone)
+
+  def get_slide_attrs(self):
+    return list(self.slide_attrs)
+
+  def get_lookzone_attrs(self):
+    return list(self.lookzone_attrs)
+
+  # open and read input Excel files to get attributes
+  def load_input_files(self):
+    self.all_readers = []
+    # keep track of how much progress we've made opening/reading files
+    opened_files = 0
+    num_files = len(self.experimentFilePaths)
+    # For each file in the list of files, create a reader and get all of its attributes
+    for filePath in self.experimentFilePaths:
+      # First parse the experiment from the saved file path
+      reader = WorkbookReader(str(filePath))
+
+      self.all_readers.append(reader)
+
+      # get the lookzone and slide attributes from the reader
+      attrs = reader.get_attributes()
+      self.lookzone_attrs = attrs['lookzone'];
+      self.slide_attrs = attrs['slide'];
+
+      # update progress bar on successful file open
+      opened_files += 1
+      ratio = opened_files / float(num_files)
+      percent_done = ratio * 100
+
+      self.notifyProgress.emit(percent_done)
+
+    # Then if there is a config file to load, load it
+    if len(self.configFilePath):
+      saved_attrs = Configuration.read_config_file(self.configFilePath)
+      self.saved_slide.update(saved_attrs['slide'])
+      self.saved_lookzone.update(saved_attrs['lookzone'])
+
+  def run(self):
+    self.load_input_files()
+    # notify the GUI that the task is done
+    self.notifyFinished.emit(1)

--- a/Views/selectAttributes.py
+++ b/Views/selectAttributes.py
@@ -11,10 +11,10 @@ from navigation import NavigationWidget
 class SelectAttributesWidget(QtGui.QWidget):
   procNext = QtCore.pyqtSignal()
 
-  def __init__(self, window, lookzone_attrs, slide_attrs, saved_slide, saved_lookzone):
+  def __init__(self, window, slide_attrs, lookzone_attrs, saved_slide, saved_lookzone):
     QtGui.QWidget.__init__(self)
-    self.lookzone_attrs = lookzone_attrs
     self.slide_attrs = slide_attrs
+    self.lookzone_attrs = lookzone_attrs
     self.saved_slide = saved_slide
     self.saved_lookzone = saved_lookzone
     self.window = window


### PR DESCRIPTION
Adds a progress bar for loading and reading input files. This voids the strategy used previously to catch and display iPatch errors on the load file view, so we will have to redo that (per this commit, these errors will not appear or be caught since the reading is done in the new view).
